### PR TITLE
Remove non-functional CSS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,16 +65,17 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.target.tagName === 'A') {
         const elp = e.target.parentElement
         if (elp.tagName === 'LI') {
-          if (elp.classList.contains('active')) {
+          if (elp.classList.contains('open')) {
             requestAnimationFrame(() => {
-              elp.classList.remove('active')
+              elp.classList.add('collapse')
               elp.classList.remove('open')
               elp.classList.add('hold')
             })
           } else {
             requestAnimationFrame(() => {
               if (elp.classList.contains('hold')) {
-                elp.classList.add('active')
+                elp.classList.remove('collapse')
+                elp.classList.add('open')
                 elp.classList.remove('hold')
               }
             })

--- a/src/style.css
+++ b/src/style.css
@@ -11,7 +11,7 @@
 }
 
 .sidebar-nav .open > ul:not(.app-sub-sidebar),
-.sidebar-nav .active > ul {
+.sidebar-nav .active:not(.hold) > ul {
   display: block;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,48 +1,3 @@
-.sidebar-nav li {
-  position: relative;
-  margin: 0;
-}
-.sidebar-nav a {
-  text-decoration: none;
-  padding-left: 8px;
-}
-.sidebar-nav > ul > li > ul a::before {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 15px;
-  width: 6px;
-  border-left: 1px solid #e7e7eb;
-  border-bottom: 1px solid #e7e7eb;
-}
-.sidebar-nav > ul > li > ul a::after {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 6px;
-  border-left: 1px solid #e7e7eb;
-}
-.sidebar-nav li:last-child > a::after {
-  display: none;
-}
-
-.sidebar-nav .app-sub-sidebar a::before,
-.sidebar-nav .app-sub-sidebar a::after {
-  display: none;
-}
-
-.app-sub-sidebar li::before {
-  content: '#';
-}
-
-.sidebar-nav a:hover {
-  background: #eff1f3;
-}
 .sidebar-nav > ul > li ul {
   display: none;
 }
@@ -50,6 +5,7 @@
 .app-sub-sidebar {
   display: none;
 }
+
 .app-sub-sidebar.open {
   display: block;
 }


### PR DESCRIPTION
The themed CSS wasn't working with my theme. Seems sensible to remove it as it's not integral to what the plugin actual does